### PR TITLE
Add reviewer roles and process scaffolding

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,1 @@
+# GitHub Workflows

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+- Always consult `docs/ROLES_PROMPTS.md` before starting a task or review.
+- For each task, open the prompts for the responsible role and all reviewer roles.
+- Store dialog transcripts in the appropriate `tasks/task_XX/` folder.
+- Follow the guidelines in `process/PROCESS_TEMPLATE.md` when reviewing tasks.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 This repository houses planning documents for the Waterfall-Docs-Repo project. The main checklist lives in [docs/planning/PROJECT_PLAN.md](docs/planning/PROJECT_PLAN.md).
 
 For new projects, start from the [Project Plan Template](docs/planning/PROJECT_PLAN_TEMPLATE.md) and see [PROJECT_PLAN_PROMPT.md](docs/planning/PROJECT_PLAN_PROMPT.md) for the prompt that generated the current plan.
+
+Role prompts are documented in [docs/ROLES_PROMPTS.md](docs/ROLES_PROMPTS.md). Review processes are outlined in [process/PROCESS_TEMPLATE.md](process/PROCESS_TEMPLATE.md), and dialog transcripts reside in the `tasks/` directory.

--- a/docs/ROLES_PROMPTS.md
+++ b/docs/ROLES_PROMPTS.md
@@ -1,0 +1,11 @@
+# Roles and Prompts
+
+| Role | Prompt |
+| ---- | ------ |
+| Project Manager | "Ensure tasks are planned, documented, and tracked. When reviewing, verify alignment with overall schedule." |
+| Architect | "Design the technical structure. Review tasks for architectural consistency and scalability." |
+| Systems Analyst | "Define and analyze requirements. Review tasks for completeness of requirements." |
+| Programmer | "Implement code according to specifications. Review tasks for code quality and test coverage." |
+| DevOps | "Maintain CI/CD pipelines and infrastructure. Review tasks for automation and deployment readiness." |
+| QA Lead | "Create and execute test plans. Review tasks for adequate testing and quality gates." |
+| Support Lead | "Plan maintenance and support processes. Review tasks for sustainability and user impact." |

--- a/docs/planning/PROJECT_PLAN.md
+++ b/docs/planning/PROJECT_PLAN.md
@@ -2,21 +2,24 @@
 
 *This file enumerates every task required to fully generate and operationalize the **Waterfall‑Docs‑Repo**. Each task includes a clear Definition of Done so contributors can verify completion.*
 
-| #  | Task | Responsible Role | DoD (Definition of Done) | Status |
-| -- | ---- | ---------------- | ------------------------ | ------ |
-| 1  | **Initialize repository scaffold** (root folders `/docs`, `/src`, `/linters`, `/metrics`, `.github/workflows`) | Project Manager | All directories created, pushed to `main`, README stub present. | Pending |
-| 2  | **Add README.md & LICENSE** | Project Manager | README outlines purpose & structure; LICENSE file committed; both pass `doc_linter`. | Pending |
-| 3  | **Author core templates** (`ARCHITECTURE_TEMPLATE.md`, `SRS_TEMPLATE.md`, `TESTPLAN_TEMPLATE.md`, etc.) | Architect | Each template contains only section headings + field descriptions; token ≤ 3000; passes `doc_linter`. | Pending |
-| 4  | **Create example artifacts** (`*_EXAMPLE.md`) demonstrating template use | Systems Analyst & Architect | Example docs fully populated for this repo, reference IDs valid, lint‑clean. | Pending |
-| 5  | **Implement linters** (`doc_linter.py`, `srs_linter.py`, `testplan_linter.py`, `code_linter.py`) | Programmer | Linters execute via CLI and exit non‑zero on first rule violation; unit tests cover ≥90% branches; CI passes. | Pending |
-| 6  | **Add metrics scripts** (`metrics/count_tokens.py`, `metrics/complexity.py`, `metrics/pr_latency.py`) | Architect | Scripts output JSON with metric name/value; integration test proves Prometheus push succeeds (mock). | Pending |
-| 7  | **Configure CI workflows** (`ci.yml`, `metrics.yml`) | DevOps | On every PR CI runs all linters + tests; status badge green on `main`; secrets set for metrics push. | Pending |
-| 8  | **Write QA Test Plan & test cases** (`docs/TEST_PLAN.md`, `docs/TEST_CASES.md`) | QA Lead | Documents exist, pass `testplan_linter`; traceability matrix links each requirement to at least one test case. | Pending |
-| 9  | **Populate Role / Prompt / Linter registry** (`ROLES_PROMPTS_LINTERS.md`) | Project Manager | Table lists all roles, prompt skeletons, linter mapping; reviewed by Architect & QA. | Pending |
-| 10 | **Implement architecture metrics dashboard config** (`metrics/grafana/*.json`) | DevOps | JSON dashboards imported into Grafana test instance showing real data; screenshot attached to PR. | Pending |
-| 11 | **Add CONTRIBUTING.md & pre‑commit hook** to run linters pre‑push | Project Manager & Programmer | Hook blocks commit on linter failure; CONTRIBUTING lists setup steps; validated on a fresh clone. | Pending |
-| 12 | **Create Maintenance & Support Plan** (`docs/MAINTENANCE_PLAN.md`) | Support Lead | Plan covers issue triage, SLAs, routine tasks; approved by PM; passes `doc_linter`. | Pending |
-| 13 | **Phase‑gate review & baseline** | Project Manager | All artifacts frozen at v1.0 tag; RTM complete; milestone closed in project board. | Pending |
+| #  | Task | Responsible Role | Reviewer Roles | DoD (Definition of Done) | Status |
+| -- | ---- | ---------------- | -------------- | ------------------------ | ------ |
+| 0  | **Create reviewer roles and prompts** (`docs/ROLES_PROMPTS.md`, `AGENTS.md`) | Project Manager | Architect | Roles file with prompts exists; root instructions reference it. | Done |
+| 1  | **Initialize repository scaffold** (root folders `/docs`, `/src`, `/linters`, `/metrics`, `.github/workflows`) | Project Manager | Architect | All directories created, pushed to `main`, README stub present. ✅ | Done |
+| 2  | **Add README.md & LICENSE** | Project Manager | Systems Analyst | README outlines purpose & structure; LICENSE file committed; both pass `doc_linter`. | Pending |
+| 3  | **Author core templates** (`ARCHITECTURE_TEMPLATE.md`, `SRS_TEMPLATE.md`, `TESTPLAN_TEMPLATE.md`, etc.) | Architect | Project Manager | Each template contains only section headings + field descriptions; token ≤ 3000; passes `doc_linter`. | Pending |
+| 4  | **Create example artifacts** (`*_EXAMPLE.md`) demonstrating template use | Systems Analyst & Architect | QA Lead | Example docs fully populated for this repo, reference IDs valid, lint‑clean. | Pending |
+| 5  | **Implement linters** (`doc_linter.py`, `srs_linter.py`, `testplan_linter.py`, `code_linter.py`) | Programmer | QA Lead | Linters execute via CLI and exit non‑zero on first rule violation; unit tests cover ≥90% branches; CI passes. | Pending |
+| 6  | **Add metrics scripts** (`metrics/count_tokens.py`, `metrics/complexity.py`, `metrics/pr_latency.py`) | Architect | DevOps | Scripts output JSON with metric name/value; integration test proves Prometheus push succeeds (mock). | Pending |
+| 7  | **Configure CI workflows** (`ci.yml`, `metrics.yml`) | DevOps | Programmer | On every PR CI runs all linters + tests; status badge green on `main`; secrets set for metrics push. | Pending |
+| 8  | **Write QA Test Plan & test cases** (`docs/TEST_PLAN.md`, `docs/TEST_CASES.md`) | QA Lead | Support Lead | Documents exist, pass `testplan_linter`; traceability matrix links each requirement to at least one test case. | Pending |
+| 9  | **Populate Role / Prompt / Linter registry** (`ROLES_PROMPTS_LINTERS.md`) | Project Manager | Architect | Table lists all roles, prompt skeletons, linter mapping; reviewed by Architect & QA. | Pending |
+| 10 | **Implement architecture metrics dashboard config** (`metrics/grafana/*.json`) | DevOps | Architect | JSON dashboards imported into Grafana test instance showing real data; screenshot attached to PR. | Pending |
+| 11 | **Add CONTRIBUTING.md & pre‑commit hook** to run linters pre‑push | Project Manager & Programmer | QA Lead | Hook blocks commit on linter failure; CONTRIBUTING lists setup steps; validated on a fresh clone. | Pending |
+| 12 | **Create Maintenance & Support Plan** (`docs/MAINTENANCE_PLAN.md`) | Support Lead | Project Manager | Plan covers issue triage, SLAs, routine tasks; approved by PM; passes `doc_linter`. | Pending |
+| 13 | **Phase‑gate review & baseline** | Project Manager | Architect, QA Lead | All artifacts frozen at v1.0 tag; RTM complete; milestone closed in project board. | Pending |
+| 14 | **Audit task list for role & reviewer coverage** | Project Manager | Architect | Every task has clearly defined responsible and reviewer roles. | Pending |
+
 > **Progress Tracking:** Update the Status column and add ✅ in the DoD column once criteria are met.
 
 ---

--- a/docs/planning/PROJECT_PLAN_TEMPLATE.md
+++ b/docs/planning/PROJECT_PLAN_TEMPLATE.md
@@ -1,8 +1,8 @@
 # Project Plan Template
 
-Use this template to outline all tasks required for a project. Populate each row with a concise description, assign a responsible role, and clearly state the definition of done. Update the **Status** column with the current progress.
+Use this template to outline all tasks required for a project. Populate each row with a concise description, assign a responsible role, designate at least one reviewer role, and clearly state the definition of done. Update the **Status** column with the current progress.
 
-| # | Task | Responsible Role | DoD (Definition of Done) | Status |
-| - | ---- | ---------------- | ------------------------ | ------ |
-| 1 | _Task description_ | _Role_ | _Completion criteria_ | Pending |
-| 2 | _..._ | _..._ | _..._ | Pending |
+| # | Task | Responsible Role | Reviewer Roles | DoD (Definition of Done) | Status |
+| - | ---- | ---------------- | -------------- | ------------------------ | ------ |
+| 1 | _Task description_ | _Role_ | _Reviewer_ | _Completion criteria_ | Pending |
+| 2 | _..._ | _..._ | _..._ | _..._ | Pending |

--- a/linters/README.md
+++ b/linters/README.md
@@ -1,0 +1,1 @@
+# Linters

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,0 +1,1 @@
+# Metrics

--- a/process/PROCESS_TEMPLATE.md
+++ b/process/PROCESS_TEMPLATE.md
@@ -1,0 +1,10 @@
+# Process Template
+
+For each task in `docs/planning/PROJECT_PLAN.md`:
+
+1. Identify the **Responsible Role** and the **Reviewer Roles**.
+2. Read the corresponding prompts for those roles in `docs/ROLES_PROMPTS.md`.
+3. Review the task description and Definition of Done.
+4. Answer the review questions for clarity, blockers, and resources.
+5. Record any dialog or decision making in `tasks/task_XX/` where `XX` is the task number.
+6. Create follow‑up tasks as needed and store them within the same folder.

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,1 @@
+# Source Code

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -1,0 +1,2 @@
+# Task Dialogs
+This folder stores dialog transcripts for each task. Each subfolder task_XX contains notes and exchanges.

--- a/tasks/task_00/README.md
+++ b/tasks/task_00/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 00

--- a/tasks/task_01/README.md
+++ b/tasks/task_01/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 01

--- a/tasks/task_02/README.md
+++ b/tasks/task_02/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 02

--- a/tasks/task_03/README.md
+++ b/tasks/task_03/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 03

--- a/tasks/task_04/README.md
+++ b/tasks/task_04/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 04

--- a/tasks/task_05/README.md
+++ b/tasks/task_05/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 05

--- a/tasks/task_06/README.md
+++ b/tasks/task_06/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 06

--- a/tasks/task_07/README.md
+++ b/tasks/task_07/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 07

--- a/tasks/task_08/README.md
+++ b/tasks/task_08/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 08

--- a/tasks/task_09/README.md
+++ b/tasks/task_09/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 09

--- a/tasks/task_10/README.md
+++ b/tasks/task_10/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 10

--- a/tasks/task_11/README.md
+++ b/tasks/task_11/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 11

--- a/tasks/task_12/README.md
+++ b/tasks/task_12/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 12

--- a/tasks/task_13/README.md
+++ b/tasks/task_13/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 13

--- a/tasks/task_14/README.md
+++ b/tasks/task_14/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 14


### PR DESCRIPTION
## Summary
- document role prompts and new agent instructions
- include a process template for reviewing tasks
- expand the project plan with reviewer roles and additional tasks
- create task folders to store dialog transcripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683a4664bd38832c8585b5617fdfe8f7