### PR TITLE
Add placeholder linters and review notes

### DIFF
--- a/linters/code_linter.py
+++ b/linters/code_linter.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Placeholder code linter."""
+
+def main():
+    print("code_linter not implemented yet")
+
+if __name__ == "__main__":
+    main()

--- a/linters/doc_linter.py
+++ b/linters/doc_linter.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Placeholder doc linter."""
+
+def main():
+    print("doc_linter not implemented yet")
+
+if __name__ == "__main__":
+    main()

--- a/linters/srs_linter.py
+++ b/linters/srs_linter.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Placeholder SRS linter."""
+
+def main():
+    print("srs_linter not implemented yet")
+
+if __name__ == "__main__":
+    main()

--- a/linters/testplan_linter.py
+++ b/linters/testplan_linter.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Placeholder test plan linter."""
+
+def main():
+    print("testplan_linter not implemented yet")
+
+if __name__ == "__main__":
+    main()

--- a/tasks/task_02/README.md
+++ b/tasks/task_02/README.md
@@ -1,1 +1,13 @@
 # Dialogs for task 02
+
+## Review for Task 2
+**Responsible:** Project Manager
+**Reviewer:** Systems Analyst
+
+### Task Description
+Add README.md & LICENSE. README outlines purpose & structure; LICENSE file committed; both pass `doc_linter`.
+
+### Review Notes
+- **Clarity:** Task description and DoD are clear.
+- **Blockers:** `doc_linter` script not yet implemented (pending Task 5).
+- **Resources:** Existing README template, standard license text, doc_linter once available.

--- a/tasks/task_02/followups.md
+++ b/tasks/task_02/followups.md
@@ -1,0 +1,2 @@
+- Create doc_linter script (Task 5) before marking this task complete.
+- Choose an appropriate open-source license.

--- a/tasks/task_05/README.md
+++ b/tasks/task_05/README.md
@@ -1,1 +1,14 @@
 # Dialogs for task 05
+
+## Review for Task 5
+**Responsible:** Programmer
+**Reviewer:** QA Lead
+
+### Task Description
+Implement linters `doc_linter.py`, `srs_linter.py`, `testplan_linter.py`, `code_linter.py`. Linters execute via CLI and exit non-zero on first rule violation; unit tests cover ≥90% branches; CI passes.
+
+### Review Notes
+- **Clarity:** DoD specifies execution and coverage targets, but specific lint rules and dependencies are not yet defined.
+- **Blockers:** Need guidance on required libraries and rule sets before implementing logic.
+- **Resources:** Will consult project stakeholders for recommended linting libraries.
+- Placeholder linter scripts will be created with basic CLI to ensure they run.

--- a/tasks/task_05/followups.md
+++ b/tasks/task_05/followups.md
@@ -1,0 +1,3 @@
+- Confirm available linting libraries and rule requirements with project stakeholders.
+- Maintain placeholder linter scripts until specifications are ready.
+- Ensure each linter executes via CLI without errors.


### PR DESCRIPTION
## Summary
- start documenting Task 5 review and follow-ups
- add placeholder linter scripts with minimal CLI

## Testing
- `./linters/doc_linter.py`
- `./linters/srs_linter.py`
- `./linters/testplan_linter.py`
- `./linters/code_linter.py`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683a59092a58832c961724ad5232fc97