### PR TITLE
Add task followups and DAG linter

### DIFF
--- a/docs/planning/PROJECT_PLAN.md
+++ b/docs/planning/PROJECT_PLAN.md
@@ -19,6 +19,7 @@
 | 12 | **Create Maintenance & Support Plan** (`docs/MAINTENANCE_PLAN.md`) | Support Lead | Project Manager | Plan covers issue triage, SLAs, routine tasks; approved by PM; passes `doc_linter`. | Pending |
 | 13 | **Phase‑gate review & baseline** | Project Manager | Architect, QA Lead | All artifacts frozen at v1.0 tag; RTM complete; milestone closed in project board. | Pending |
 | 14 | **Audit task list for role & reviewer coverage** | Project Manager | Architect | Every task has clearly defined responsible and reviewer roles. | Pending |
+| 15 | **Add task DAG linter** (`linters/task_dag_linter.py`) | Programmer | QA Lead | Linter verifies tasks form a DAG and docs are up to date. | Pending |
 
 > **Progress Tracking:** Update the Status column and add ✅ in the DoD column once criteria are met.
 

--- a/linters/task_dag_linter.py
+++ b/linters/task_dag_linter.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Check that tasks form a DAG and documentation is consistent."""
+import os
+import re
+import sys
+from collections import defaultdict, deque
+
+PLAN_PATH = os.path.join('docs', 'planning', 'PROJECT_PLAN.md')
+TASKS_DIR = 'tasks'
+
+# Extract task numbers from project plan
+TASK_PATTERN = re.compile(r"^\|\s*(\d+)\s+\|")
+
+def parse_tasks():
+    ids = []
+    with open(PLAN_PATH, 'r', encoding='utf-8') as f:
+        for line in f:
+            m = TASK_PATTERN.match(line)
+            if m:
+                ids.append(int(m.group(1)))
+    return ids
+
+# Extract dependencies from followups files
+DEP_PATTERN = re.compile(r"Depends on:\s*([0-9, ]+)", re.IGNORECASE)
+
+def parse_deps(task_id):
+    path = os.path.join(TASKS_DIR, f"task_{task_id:02d}", 'followups.md')
+    deps = []
+    if os.path.exists(path):
+        with open(path, 'r', encoding='utf-8') as f:
+            for line in f:
+                m = DEP_PATTERN.search(line)
+                if m:
+                    parts = re.split(r"[, ]+", m.group(1).strip())
+                    for p in parts:
+                        if p.isdigit():
+                            deps.append(int(p))
+    return deps
+
+# Topological check
+
+def check_dag(ids, dependencies):
+    indeg = {i: 0 for i in ids}
+    graph = defaultdict(list)
+    for t, deps in dependencies.items():
+        for d in deps:
+            if d not in ids:
+                raise ValueError(f"Task {t} depends on unknown task {d}")
+            graph[d].append(t)
+            indeg[t] += 1
+    # Kahn's algorithm
+    q = deque([i for i in ids if indeg[i] == 0])
+    visited = []
+    while q:
+        n = q.popleft()
+        visited.append(n)
+        for v in graph[n]:
+            indeg[v] -= 1
+            if indeg[v] == 0:
+                q.append(v)
+    if len(visited) != len(ids):
+        raise ValueError('Cycle detected in task dependencies')
+
+
+def main():
+    ids = parse_tasks()
+    if ids != sorted(ids) or ids != list(range(ids[0], ids[-1] + 1)):
+        print('Task numbers in project plan are not sequential')
+        sys.exit(1)
+    deps = {i: parse_deps(i) for i in ids}
+    try:
+        check_dag(ids, deps)
+    except ValueError as e:
+        print(str(e))
+        sys.exit(1)
+    print('Task DAG OK')
+
+if __name__ == '__main__':
+    main()

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -1,2 +1,2 @@
 # Task Dialogs
-This folder stores dialog transcripts for each task. Each subfolder task_XX contains notes and exchanges.
+This folder stores dialog transcripts for each task. Each subfolder `task_XX` contains notes, follow-up items, and dependency links to documentation.

--- a/tasks/task_00/followups.md
+++ b/tasks/task_00/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/ROLES_PROMPTS.md
+- Depends on: none

--- a/tasks/task_01/followups.md
+++ b/tasks/task_01/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 0

--- a/tasks/task_02/followups.md
+++ b/tasks/task_02/followups.md
@@ -1,2 +1,4 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 1, 5
 - Create doc_linter script (Task 5) before marking this task complete.
 - Choose an appropriate open-source license.

--- a/tasks/task_03/followups.md
+++ b/tasks/task_03/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 2

--- a/tasks/task_04/followups.md
+++ b/tasks/task_04/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 3

--- a/tasks/task_05/followups.md
+++ b/tasks/task_05/followups.md
@@ -1,3 +1,5 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 1
 - Confirm available linting libraries and rule requirements with project stakeholders.
 - Maintain placeholder linter scripts until specifications are ready.
 - Ensure each linter executes via CLI without errors.

--- a/tasks/task_06/followups.md
+++ b/tasks/task_06/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 5

--- a/tasks/task_07/followups.md
+++ b/tasks/task_07/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 5, 6

--- a/tasks/task_08/followups.md
+++ b/tasks/task_08/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 3, 4

--- a/tasks/task_09/followups.md
+++ b/tasks/task_09/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 0, 5

--- a/tasks/task_10/followups.md
+++ b/tasks/task_10/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 6

--- a/tasks/task_11/followups.md
+++ b/tasks/task_11/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 5

--- a/tasks/task_12/followups.md
+++ b/tasks/task_12/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 8, 11

--- a/tasks/task_13/followups.md
+++ b/tasks/task_13/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 12

--- a/tasks/task_14/followups.md
+++ b/tasks/task_14/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 13

--- a/tasks/task_15/README.md
+++ b/tasks/task_15/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 15

--- a/tasks/task_15/followups.md
+++ b/tasks/task_15/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 14


### PR DESCRIPTION
## Summary
- add followups for each task and link docs
- introduce `task_dag_linter.py` to ensure task dependencies form a DAG
- mention follow-ups in tasks README
- register new task for the DAG linter in PROJECT_PLAN

## Testing
- `python linters/task_dag_linter.py`

------
https://chatgpt.com/codex/tasks/task_e_683a60369d64832cb5ca10a3ce36ae24