### PR TITLE
Update agent guidance and add planning tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,6 @@
 - For each task, open the prompts for the responsible role and all reviewer roles.
 - Store dialog transcripts in the appropriate `tasks/task_XX/` folder.
 - Follow the guidelines in `process/PROCESS_TEMPLATE.md` when reviewing tasks.
+- Start from `docs/planning/PROJECT_PLAN.md` to identify the active task.
+- When assigned a task, read the process guide and the chosen role prompt before creating, modifying, or removing files.
+- Work on one task at a time.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ and dialog transcripts reside in the `tasks/` directory.
 ## Repository Structure
 
 - `docs/` – planning documents and templates
+  - `architecture/` – templates, prompts, and examples for design diagrams
+  - `spc/` – specification templates and example artifacts
 - `linters/` – custom linting scripts
 - `metrics/` – metrics collection utilities
 - `process/` – process documentation

--- a/docs/planning/PROJECT_PLAN.md
+++ b/docs/planning/PROJECT_PLAN.md
@@ -20,6 +20,9 @@
 | 13 | **Phase‑gate review & baseline** | Project Manager | Architect, QA Lead | All artifacts frozen at v1.0 tag; RTM complete; milestone closed in project board. | Pending |
 | 14 | **Audit task list for role & reviewer coverage** | Project Manager | Architect | Every task has clearly defined responsible and reviewer roles. | Pending |
 | 15 | **Add task DAG linter** (`linters/task_dag_linter.py`) | Programmer | QA Lead | Linter verifies tasks form a DAG and docs are up to date. | Pending |
+| 16 | **Populate architecture folder** (`docs/architecture/`) with templates, prompts, example diagrams and dedicated linters | Architect | Project Manager | Folder README outlines structure; files exist as separate templates, prompts, examples; each diagram validated by its linter. | Pending |
+| 17 | **Populate specification folder** (`docs/spc/`) with templates, prompts, examples and diagram linters | Systems Analyst | Architect | README explains layout; individual files added; lint passes for each diagram. | Pending |
+| 18 | **Research retrospective on redundant steps** | Project Manager | Architect | Document detailing redundant steps and lessons learned added to `docs/RESEARCH_RETROSPECTIVE.md`. | Pending |
 
 > **Progress Tracking:** Update the Status column and add ✅ in the DoD column once criteria are met.
 


### PR DESCRIPTION
## Summary
- note to always start from plan and process guides
- document new `architecture/` and `spc/` directories in repo structure
- append tasks for populating new folders and performing retrospective research

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a8e98b488832c831b600333854120