### PR TITLE
Add task create and execute processes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,30 @@
 # Agent Instructions
 
-- Always consult `docs/ROLES_PROMPTS.md` before starting a task or review.
-- For each task, open the prompts for the responsible role and all reviewer roles.
-- Store dialog transcripts in the appropriate `tasks/task_XX/` folder.
-- Follow the guidelines in `process/PROCESS_TEMPLATE.md` when reviewing tasks.
-- Start from `docs/planning/PROJECT_PLAN.md` to identify the active task.
-- When assigned a task, read the process guide and the chosen role prompt before creating, modifying, or removing files.
+The repository defines processes for creating and executing tasks.
+
+## Execute a Task
+1. Locate the active task in `docs/planning/PROJECT_PLAN.md`.
+2. Review the prompts for the responsible and reviewer roles in
+   `docs/ROLES_PROMPTS.md`.
+3. Read any notes for the task in `tasks/task_XX/`.
+4. Record dialog and decisions in `tasks/task_XX/README.md` and update
+   `followups.md` with dependencies.
+5. Follow the checklist in `process/PROCESS_TEMPLATE.md`.
+
+More detail is available in `process/EXECUTE_TASK.md`.
+
+## Create a Task
+When defining a new task or follow-up, use `process/CREATE_TASK.md` for the
+steps to add it to the project plan and initialize the task folder.
+
 - Work on one task at a time.
+
+## Reflect on the Work
+After completing a task:
+1. Add a bullet under **Lessons Learned** summarizing what to repeat or avoid.
+2. Update relevant process docs if a new step is required.
+
+### Lessons Learned
+- Avoid scanning the `tasks/` directory to discover new work. Use
+  `docs/planning/PROJECT_PLAN.md` or `python src/random_task.py` to select a
+  pending task.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Role prompts are documented in [docs/ROLES_PROMPTS.md](docs/ROLES_PROMPTS.md).
 Review processes are outlined in [process/PROCESS_TEMPLATE.md](process/PROCESS_TEMPLATE.md),
 and dialog transcripts reside in the `tasks/` directory.
 
+Use `python src/random_task.py` to fetch a random task from the project plan.
+
 ## Repository Structure
 
 - `docs/` – planning documents and templates
@@ -19,7 +21,7 @@ and dialog transcripts reside in the `tasks/` directory.
 - `linters/` – custom linting scripts
 - `metrics/` – metrics collection utilities
 - `process/` – process documentation
-- `src/` – project source code samples
+- `src/` – project source code samples including `random_task.py`
 - `tasks/` – conversation transcripts and follow-ups
 - `tests/` – unit tests for repository tools
 

--- a/docs/ARCHITECTURE_TEMPLATE.md
+++ b/docs/ARCHITECTURE_TEMPLATE.md
@@ -5,6 +5,8 @@ Describe the overall system and its goals.
 
 ## Components
 List major components and their responsibilities.
+- Task selector script (`src/random_task.py`) picks a random unblocked task from
+  `docs/planning/PROJECT_PLAN.md`.
 
 ## Data Flow
 Explain how data moves between components.

--- a/process/CREATE_TASK.md
+++ b/process/CREATE_TASK.md
@@ -1,0 +1,17 @@
+# Create Task Process
+
+Use this process whenever you add a new task or generate a follow-up task.
+
+1. Review `docs/planning/PROJECT_PLAN.md` to determine the next task number.
+2. Define the task summary, Responsible Role and Reviewer Roles. Ensure the
+   roles exist in `docs/ROLES_PROMPTS.md`.
+3. Append a new row to `docs/planning/PROJECT_PLAN.md` with the task details and
+   status `Pending`.
+4. Create a directory `tasks/task_XX` where `XX` is the task number.
+   - Add `README.md` with the heading `# Dialogs for task XX`.
+   - Add `followups.md` and list any dependencies in the form
+     `Depends on: <task numbers>`.
+5. Decompose large work into smaller follow-up tasks and record them in
+   `followups.md`.
+6. Reference related documentation using relative paths.
+

--- a/process/EXECUTE_TASK.md
+++ b/process/EXECUTE_TASK.md
@@ -1,0 +1,15 @@
+# Execute Task Process
+
+Follow these steps whenever you work on an existing task.
+
+1. Open `docs/planning/PROJECT_PLAN.md` to locate the next task marked `Pending`.
+   You can run `python src/random_task.py` to select a random unblocked task.
+2. Note the Responsible Role and Reviewer Roles listed for that task.
+3. Read the matching prompts in `docs/ROLES_PROMPTS.md`.
+4. Navigate to `tasks/task_XX/` where `XX` is the task number.
+5. Record dialog and decisions in `README.md` and update `followups.md` with any
+   dependencies or follow-up items.
+6. Use the checklist in `process/PROCESS_TEMPLATE.md` when reviewing work.
+7. Commit changes that satisfy the task's Definition of Done.
+8. Append any lessons learned to `AGENTS.md` under **Lessons Learned**.
+

--- a/src/random_task.py
+++ b/src/random_task.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Select a random unblocked task from PROJECT_PLAN.md."""
+
+import random
+from pathlib import Path
+
+PLAN_PATH = Path(__file__).resolve().parents[1] / "docs" / "planning" / "PROJECT_PLAN.md"
+
+
+def parse_plan(plan_path: Path) -> list:
+    tasks = []
+    with plan_path.open() as f:
+        for line in f:
+            if line.startswith('|') and line.count('|') >= 6:
+                cells = [c.strip() for c in line.strip().strip('|').split('|')]
+                if not cells[0].isdigit():
+                    continue
+                status = cells[-1].lower()
+                if status not in {"done", "blocked"}:
+                    tasks.append(int(cells[0]))
+    return tasks
+
+
+def get_random_task() -> int | None:
+    avail = parse_plan(PLAN_PATH)
+    return random.choice(avail) if avail else None
+
+
+def main() -> int:
+    task = get_random_task()
+    if task is None:
+        print("No pending tasks")
+        return 1
+    print(f"task_{task:02d}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_random_task.py
+++ b/tests/test_random_task.py
@@ -1,0 +1,22 @@
+import textwrap
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+import random_task
+
+
+def test_parse_plan(tmp_path, monkeypatch):
+    plan = tmp_path / "PROJECT_PLAN.md"
+    plan.write_text(textwrap.dedent(
+        """
+        | # | Task | Responsible Role | Reviewer Roles | DoD | Status |
+        | 1 | Do thing | Dev | QA | Done when done | Pending |
+        | 2 | Blocked task | Dev | QA | When done | Blocked |
+        | 3 | Another | Dev | QA | When done | Done |
+        """
+    ))
+    monkeypatch.setattr(random_task, "PLAN_PATH", plan)
+    tasks = random_task.parse_plan(plan)
+    assert tasks == [1]
+    task = random_task.get_random_task()
+    assert task == 1


### PR DESCRIPTION
## Summary
- rewrite `AGENTS.md` with direct instructions for executing a task
- link to new task creation and execution process docs
- document detailed procedures in `process/CREATE_TASK.md` and `process/EXECUTE_TASK.md`


------
https://chatgpt.com/codex/tasks/task_e_683a91c90924832ca08667973a0a7992