### PR TITLE
Add roles template task and simplify instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,17 @@
 # Agent Instructions
 
-The repository defines processes for creating and executing tasks.
+The repository defines two processes: executing an existing task or creating a
+new one.
 
 ## Execute a Task
-1. Locate the active task in `docs/planning/PROJECT_PLAN.md`.
-2. Review the prompts for the responsible and reviewer roles in
-   `docs/ROLES_PROMPTS.md`.
-3. Read any notes for the task in `tasks/task_XX/`.
-4. Record dialog and decisions in `tasks/task_XX/README.md` and update
-   `followups.md` with dependencies.
-5. Follow the checklist in `process/PROCESS_TEMPLATE.md`.
-
-More detail is available in `process/EXECUTE_TASK.md`.
+If the request is to **execute a task**, follow the step-by-step instructions
+provided by the script. Role prompts are located in
+`docs/ROLES_PROMPTS.md` and each role may have a template under
+`docs/roles/`.
 
 ## Create a Task
-When defining a new task or follow-up, use `process/CREATE_TASK.md` for the
-steps to add it to the project plan and initialize the task folder.
+If the request is to **create a task**, follow `process/CREATE_TASK.md` to add
+it to the project plan and create its folder.
 
 - Work on one task at a time.
 
@@ -28,3 +24,5 @@ After completing a task:
 - Avoid scanning the `tasks/` directory to discover new work. Use
   `docs/planning/PROJECT_PLAN.md` or `python src/random_task.py` to select a
   pending task.
+- Record new reference documents in each task's `followups.md` so future
+  contributors understand context.

--- a/docs/ROLES_PROMPTS_LINTERS.md
+++ b/docs/ROLES_PROMPTS_LINTERS.md
@@ -1,0 +1,13 @@
+# Roles, Prompts, and Linter Mapping
+
+This registry links each project role to its associated prompt and the linter typically used when that role produces documentation or code.
+
+| Role | Prompt | Linter |
+| ---- | ------ | ------ |
+| Project Manager | "Ensure tasks are planned, documented, and tracked. When reviewing, verify alignment with overall schedule." | doc_linter.py |
+| Architect | "Design the technical structure. Review tasks for architectural consistency and scalability." | doc_linter.py |
+| Systems Analyst | "Define and analyze requirements. Review tasks for completeness of requirements." | srs_linter.py |
+| Programmer | "Implement code according to specifications. Review tasks for code quality and test coverage." | code_linter.py |
+| DevOps | "Maintain CI/CD pipelines and infrastructure. Review tasks for automation and deployment readiness." | code_linter.py |
+| QA Lead | "Create and execute test plans. Review tasks for adequate testing and quality gates." | testplan_linter.py |
+| Support Lead | "Plan maintenance and support processes. Review tasks for sustainability and user impact." | doc_linter.py |

--- a/docs/planning/PROJECT_PLAN.md
+++ b/docs/planning/PROJECT_PLAN.md
@@ -23,6 +23,7 @@
 | 16 | **Populate architecture folder** (`docs/architecture/`) with templates, prompts, example diagrams and dedicated linters | Architect | Project Manager | Folder README outlines structure; files exist as separate templates, prompts, examples; each diagram validated by its linter. | Pending |
 | 17 | **Populate specification folder** (`docs/spc/`) with templates, prompts, examples and diagram linters | Systems Analyst | Architect | README explains layout; individual files added; lint passes for each diagram. | Pending |
 | 18 | **Research retrospective on redundant steps** | Project Manager | Architect | Document detailing redundant steps and lessons learned added to `docs/RESEARCH_RETROSPECTIVE.md`. | Pending |
+| 19 | **Create roles folder with templates** (`docs/roles/`) | Project Manager | Architect | Folder contains one template per role and a README explaining usage. | Pending |
 
 > **Progress Tracking:** Update the Status column and add ✅ in the DoD column once criteria are met.
 

--- a/tasks/task_09/README.md
+++ b/tasks/task_09/README.md
@@ -1,1 +1,17 @@
 # Dialogs for task 09
+
+## Review for Task 9
+**Responsible:** Project Manager
+**Reviewer:** Architect
+
+### Task Description
+Populate Role / Prompt / Linter registry (`ROLES_PROMPTS_LINTERS.md`). Table lists all roles, prompt skeletons, linter mapping; reviewed by Architect & QA.
+
+### Review Notes
+- **Clarity:** Requirements are clear; compile existing prompts and assign a linter per role.
+- **Blockers:** None at this time.
+- **Resources:** `docs/ROLES_PROMPTS.md`, scripts under `linters/`.
+
+## AI Notes 2025-06-01
+- Generated `docs/ROLES_PROMPTS_LINTERS.md` with a table linking each role to its prompt and usual linter.
+- Updated followups to reference the new registry.

--- a/tasks/task_09/followups.md
+++ b/tasks/task_09/followups.md
@@ -1,2 +1,3 @@
 - Reference: ../../docs/planning/PROJECT_PLAN.md
+- Reference: ../../docs/ROLES_PROMPTS_LINTERS.md
 - Depends on: 0, 5

--- a/tasks/task_19/README.md
+++ b/tasks/task_19/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 19

--- a/tasks/task_19/followups.md
+++ b/tasks/task_19/followups.md
@@ -1,0 +1,3 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 0, 9
+- Reference: ../../docs/ROLES_PROMPTS.md


### PR DESCRIPTION
## Summary
- simplify task instructions in `AGENTS.md`
- append a new task for creating role templates
- initialize folder `tasks/task_19`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683a95ca1f9c832cb42a7fa63c021f4f