### PR TITLE
Implement role prompt linter and update agent process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,7 @@ The repository defines two processes: executing an existing task or creating a
 new one.
 
 ## Execute a Task
-If the request is to **execute a task**, follow the step-by-step instructions
-provided by the script. Role prompts are located in
-`docs/ROLES_PROMPTS.md` and each role may have a template under
-`docs/roles/`.
+If the request is to **execute a task**, run `python src/random_task.py` to select a pending task. Then open the responsible role's prompt under `docs/roles/` and follow `process/EXECUTE_TASK.md`.
 
 ## Create a Task
 If the request is to **create a task**, follow `process/CREATE_TASK.md` to add
@@ -28,3 +25,4 @@ After completing a task:
   pending task.
 - Record new reference documents in each task's `followups.md` so future
   contributors understand context.
+- Split role prompts into individual files under `docs/roles/` and added a linter to enforce their format.

--- a/docs/ROLES_PROMPTS.md
+++ b/docs/ROLES_PROMPTS.md
@@ -1,11 +1,13 @@
 # Roles and Prompts
 
-| Role | Prompt |
-| ---- | ------ |
-| Project Manager | "Ensure tasks are planned, documented, and tracked. When reviewing, verify alignment with overall schedule." |
-| Architect | "Design the technical structure. Review tasks for architectural consistency and scalability." |
-| Systems Analyst | "Define and analyze requirements. Review tasks for completeness of requirements." |
-| Programmer | "Implement code according to specifications. Review tasks for code quality and test coverage." |
-| DevOps | "Maintain CI/CD pipelines and infrastructure. Review tasks for automation and deployment readiness." |
-| QA Lead | "Create and execute test plans. Review tasks for adequate testing and quality gates." |
-| Support Lead | "Plan maintenance and support processes. Review tasks for sustainability and user impact." |
+Each role prompt is stored in its own file under `docs/roles/`.
+
+| Role | File |
+| ---- | ---- |
+| Project Manager | `docs/roles/project_manager.md` |
+| Architect | `docs/roles/architect.md` |
+| Systems Analyst | `docs/roles/systems_analyst.md` |
+| Programmer | `docs/roles/programmer.md` |
+| DevOps | `docs/roles/devops.md` |
+| QA Lead | `docs/roles/qa_lead.md` |
+| Support Lead | `docs/roles/support_lead.md` |

--- a/docs/roles/architect.md
+++ b/docs/roles/architect.md
@@ -1,0 +1,2 @@
+# Architect
+Design the technical structure. Review tasks for architectural consistency and scalability.

--- a/docs/roles/devops.md
+++ b/docs/roles/devops.md
@@ -1,0 +1,2 @@
+# DevOps
+Maintain CI/CD pipelines and infrastructure. Review tasks for automation and deployment readiness.

--- a/docs/roles/programmer.md
+++ b/docs/roles/programmer.md
@@ -1,0 +1,2 @@
+# Programmer
+Implement code according to specifications. Review tasks for code quality and test coverage.

--- a/docs/roles/project_manager.md
+++ b/docs/roles/project_manager.md
@@ -1,0 +1,2 @@
+# Project Manager
+Ensure tasks are planned, documented, and tracked. When reviewing, verify alignment with overall schedule.

--- a/docs/roles/qa_lead.md
+++ b/docs/roles/qa_lead.md
@@ -1,0 +1,2 @@
+# QA Lead
+Create and execute test plans. Review tasks for adequate testing and quality gates.

--- a/docs/roles/support_lead.md
+++ b/docs/roles/support_lead.md
@@ -1,0 +1,2 @@
+# Support Lead
+Plan maintenance and support processes. Review tasks for sustainability and user impact.

--- a/docs/roles/systems_analyst.md
+++ b/docs/roles/systems_analyst.md
@@ -1,0 +1,2 @@
+# Systems Analyst
+Define and analyze requirements. Review tasks for completeness of requirements.

--- a/linters/role_linter.py
+++ b/linters/role_linter.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Linter for individual role prompt files."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from lint_utils import check_no_todo
+
+
+def check_role_file(path: Path) -> bool:
+    lines = path.read_text().splitlines()
+    if len(lines) != 2:
+        print(f"{path}: file must contain exactly two lines")
+        return False
+    if not lines[0].startswith("# "):
+        print(f"{path}: first line must start with '# '")
+        return False
+    if not lines[1].strip():
+        print(f"{path}: second line must contain prompt text")
+        return False
+    if not check_no_todo(path):
+        return False
+    return True
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Role prompt linter")
+    parser.add_argument("files", nargs="+", help="Role files to lint")
+    args = parser.parse_args(argv)
+
+    for path_str in args.files:
+        path = Path(path_str)
+        if not path.exists():
+            print(f"File not found: {path}")
+            return 1
+        if not check_role_file(path):
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_linter_cli.py
+++ b/tests/test_linter_cli.py
@@ -8,6 +8,7 @@ LINTERS = [
     'linters/srs_linter.py',
     'linters/testplan_linter.py',
     'linters/code_linter.py',
+    'linters/role_linter.py',
 ]
 
 def run_linter(script, file):
@@ -16,14 +17,20 @@ def run_linter(script, file):
 def test_linter_pass(tmp_path):
     target = tmp_path / "clean.txt"
     target.write_text("All good\n")
+    role = tmp_path / "role.md"
+    role.write_text("# Dev\nPrompt\n")
     for script in LINTERS:
-        result = run_linter(script, str(target))
+        file = role if script.endswith("role_linter.py") else target
+        result = run_linter(script, str(file))
         assert result.returncode == 0, result.stderr
 
 def test_linter_fail(tmp_path):
     target = tmp_path / "bad.txt"
     target.write_text("TODO: fix me\n")
+    role = tmp_path / "role_bad.md"
+    role.write_text("# Dev\nTODO: bad\n")
     for script in LINTERS:
-        result = run_linter(script, str(target))
+        file = role if script.endswith("role_linter.py") else target
+        result = run_linter(script, str(file))
         assert result.returncode == 1
         assert b"contains TODO" in result.stdout

--- a/tests/test_random_task.py
+++ b/tests/test_random_task.py
@@ -15,8 +15,13 @@ def test_parse_plan(tmp_path, monkeypatch):
         | 3 | Another | Dev | QA | When done | Done |
         """
     ))
+    role_dir = tmp_path / "roles"
+    role_dir.mkdir()
+    (role_dir / "dev.md").write_text("# Dev\nPrompt\n")
     monkeypatch.setattr(random_task, "PLAN_PATH", plan)
+    monkeypatch.setattr(random_task, "ROLES_DIR", role_dir)
     tasks = random_task.parse_plan(plan)
-    assert tasks == [1]
+    assert tasks[0]["id"] == 1
     task = random_task.get_random_task()
-    assert task == 1
+    assert task["id"] == 1
+    assert task["prompt"] == "Prompt"


### PR DESCRIPTION
## Summary
- break `ROLES_PROMPTS.md` into individual files under `docs/roles/`
- create `role_linter.py` to validate role prompt files
- update agent instructions to load tasks via `random_task.py`
- extend random_task to return task description and role prompt
- adjust tests for new linter and random task behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683aa2736814832c9b85faf1740bd432