### PR TITLE
Update agent instructions and random task output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,6 @@ After completing a task:
 ### Lessons Learned
 - Use stub commands in CI when dependencies are incomplete to keep workflows passing.
 - Exclude test fixtures from repository-wide linters to avoid false failures.
-- Avoid scanning the `tasks/` directory to discover new work. Use
-  `docs/planning/PROJECT_PLAN.md` or `python src/random_task.py` to select a
-  pending task.
 - Record new reference documents in each task's `followups.md` so future
   contributors understand context.
 - Split role prompts into individual files under `docs/roles/` and added a linter to enforce their format.

--- a/src/random_task.py
+++ b/src/random_task.py
@@ -4,8 +4,9 @@
 import random
 from pathlib import Path
 
-PLAN_PATH = Path(__file__).resolve().parents[1] / "docs" / "planning" / "PROJECT_PLAN.md"
-ROLES_DIR = Path(__file__).resolve().parents[1] / "docs" / "roles"
+ROOT_DIR = Path(__file__).resolve().parents[1]
+PLAN_PATH = ROOT_DIR / "docs" / "planning" / "PROJECT_PLAN.md"
+ROLES_DIR = ROOT_DIR / "docs" / "roles"
 
 
 def slugify(role: str) -> str:
@@ -43,6 +44,7 @@ def get_random_task() -> dict | None:
         return None
     chosen = random.choice(tasks)
     chosen["prompt"] = load_role_prompt(chosen["role"])
+    chosen["root"] = str(ROOT_DIR)
     return chosen
 
 
@@ -54,6 +56,7 @@ def main() -> int:
     print(f"task_{task['id']:02d}")
     print(task["task"])
     print(task["prompt"])
+    print(task["root"])
     return 0
 
 

--- a/tests/test_random_task.py
+++ b/tests/test_random_task.py
@@ -18,6 +18,7 @@ def test_parse_plan(tmp_path, monkeypatch):
     role_dir = tmp_path / "roles"
     role_dir.mkdir()
     (role_dir / "dev.md").write_text("# Dev\nPrompt\n")
+    monkeypatch.setattr(random_task, "ROOT_DIR", tmp_path)
     monkeypatch.setattr(random_task, "PLAN_PATH", plan)
     monkeypatch.setattr(random_task, "ROLES_DIR", role_dir)
     tasks = random_task.parse_plan(plan)
@@ -25,3 +26,4 @@ def test_parse_plan(tmp_path, monkeypatch):
     task = random_task.get_random_task()
     assert task["id"] == 1
     assert task["prompt"] == "Prompt"
+    assert task["root"] == str(tmp_path)


### PR DESCRIPTION
## Summary
- remove outdated tasks folder instruction from `AGENTS.md`
- return repository root path from `get_random_task`
- adjust tests for the updated script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683aa8e657ac832cbd58c80f5795a272