### PR TITLE
Update task fetcher to print execute instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ The repository defines two processes: executing an existing task or creating a
 new one.
 
 ## Execute a Task
-If the request is to **execute a task**, run `python src/random_task.py` to select a pending task. Then open the responsible role's prompt under `docs/roles/` and follow `process/EXECUTE_TASK.md`.
+If the request is to **execute a task**, run `python src/random_task.py` to select a pending task. The script prints the responsible role's prompt and the contents of `process/EXECUTE_TASK.md`.
 
 ## Create a Task
 If the request is to **create a task**, follow `process/CREATE_TASK.md` to add
@@ -18,10 +18,4 @@ After completing a task:
 2. Update relevant process docs if a new step is required.
 
 ### Lessons Learned
-- Use stub commands in CI when dependencies are incomplete to keep workflows passing.
-- Exclude test fixtures from repository-wide linters to avoid false failures.
-- Record new reference documents in each task's `followups.md` so future
-  contributors understand context.
-- Split role prompts into individual files under `docs/roles/` and added a linter to enforce their format.
-- Keep the role/prompt/linter registry updated whenever new roles or linters are introduced.
-- Capture retrospectives on redundant steps to refine future processes.
+

--- a/process/PROCESS_TEMPLATE.md
+++ b/process/PROCESS_TEMPLATE.md
@@ -8,3 +8,5 @@ For each task in `docs/planning/PROJECT_PLAN.md`:
 4. Answer the review questions for clarity, blockers, and resources.
 5. Record any dialog or decision making in `tasks/task_XX/` where `XX` is the task number.
 6. Create follow‑up tasks as needed and store them within the same folder.
+7. Use stub commands for CI when dependencies are missing to keep workflows passing.
+8. Exclude test fixtures from repository-wide linters to avoid false failures.

--- a/src/random_task.py
+++ b/src/random_task.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Select a random unblocked task and load its role prompt."""
+"""Select a random unblocked task and load its role prompt and instructions."""
 
 import random
 from pathlib import Path
@@ -7,6 +7,7 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).resolve().parents[1]
 PLAN_PATH = ROOT_DIR / "docs" / "planning" / "PROJECT_PLAN.md"
 ROLES_DIR = ROOT_DIR / "docs" / "roles"
+EXECUTE_PATH = ROOT_DIR / "process" / "EXECUTE_TASK.md"
 
 
 def slugify(role: str) -> str:
@@ -17,6 +18,11 @@ def load_role_prompt(role: str) -> str:
     path = ROLES_DIR / f"{slugify(role)}.md"
     lines = path.read_text().splitlines()
     return lines[1].strip() if len(lines) > 1 else ""
+
+
+def load_execute_instructions() -> str:
+    """Return the execute-task instructions."""
+    return EXECUTE_PATH.read_text().strip()
 
 
 def parse_plan(plan_path: Path) -> list[dict]:
@@ -44,6 +50,7 @@ def get_random_task() -> dict | None:
         return None
     chosen = random.choice(tasks)
     chosen["prompt"] = load_role_prompt(chosen["role"])
+    chosen["instructions"] = load_execute_instructions()
     chosen["root"] = str(ROOT_DIR)
     return chosen
 
@@ -56,6 +63,7 @@ def main() -> int:
     print(f"task_{task['id']:02d}")
     print(task["task"])
     print(task["prompt"])
+    print(task["instructions"])
     print(task["root"])
     return 0
 

--- a/tests/test_random_task.py
+++ b/tests/test_random_task.py
@@ -18,12 +18,16 @@ def test_parse_plan(tmp_path, monkeypatch):
     role_dir = tmp_path / "roles"
     role_dir.mkdir()
     (role_dir / "dev.md").write_text("# Dev\nPrompt\n")
+    exec_file = tmp_path / "EXECUTE_TASK.md"
+    exec_file.write_text("Do it\n")
     monkeypatch.setattr(random_task, "ROOT_DIR", tmp_path)
     monkeypatch.setattr(random_task, "PLAN_PATH", plan)
     monkeypatch.setattr(random_task, "ROLES_DIR", role_dir)
+    monkeypatch.setattr(random_task, "EXECUTE_PATH", exec_file)
     tasks = random_task.parse_plan(plan)
     assert tasks[0]["id"] == 1
     task = random_task.get_random_task()
     assert task["id"] == 1
     assert task["prompt"] == "Prompt"
+    assert task["instructions"] == "Do it"
     assert task["root"] == str(tmp_path)


### PR DESCRIPTION
## Summary
- random_task now prints EXECUTE_TASK instructions in output
- reflect change in agent instructions
- extend tests for instruction print
- drop old Lessons Learned entries
- add CI stub and fixture lint guidance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683aaddcfc74832c8a7228d3fce5469d