### PR TITLE
Add specification folder and diagram linter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,4 +20,5 @@ After completing a task:
 ### Lessons Learned
 
 - Ensure test plans include a traceability matrix linking each requirement to at least one test case.
+- Keep diagram examples minimal so linters remain simple.
 

--- a/docs/planning/PROJECT_PLAN.md
+++ b/docs/planning/PROJECT_PLAN.md
@@ -21,7 +21,7 @@
 | 14 | **Audit task list for role & reviewer coverage** | Project Manager | Architect | Every task has clearly defined responsible and reviewer roles. | Pending |
 | 15 | **Add task DAG linter** (`linters/task_dag_linter.py`) | Programmer | QA Lead | Linter verifies tasks form a DAG and docs are up to date. | Pending |
 | 16 | **Populate architecture folder** (`docs/architecture/`) with templates, prompts, example diagrams and dedicated linters | Architect | Project Manager | Folder README outlines structure; files exist as separate templates, prompts, examples; each diagram validated by its linter. | Pending |
-| 17 | **Populate specification folder** (`docs/spc/`) with templates, prompts, examples and diagram linters | Systems Analyst | Architect | README explains layout; individual files added; lint passes for each diagram. | Pending |
+| 17 | **Populate specification folder** (`docs/spc/`) with templates, prompts, examples and diagram linters | Systems Analyst | Architect | README explains layout; individual files added; lint passes for each diagram. ✅ | Done |
 | 18 | **Research retrospective on redundant steps** | Project Manager | Architect | Document detailing redundant steps and lessons learned added to `docs/RESEARCH_RETROSPECTIVE.md`. ✅ | Done |
 | 19 | **Create roles folder with templates** (`docs/roles/`) | Project Manager | Architect | Folder contains one template per role and a README explaining usage. | Pending |
 

--- a/docs/spc/README.md
+++ b/docs/spc/README.md
@@ -1,0 +1,9 @@
+# Specification Folder
+
+This directory holds templates, prompts, and example diagrams for creating detailed specifications.
+
+- `SPEC_TEMPLATE.md` – outline for a general specification document.
+- `spec_prompts.md` – guidance prompts for authors.
+- `examples/` – sample diagrams and completed specs.
+
+Use `diagram_linter.py` from `linters/` to validate PlantUML diagrams.

--- a/docs/spc/SPEC_TEMPLATE.md
+++ b/docs/spc/SPEC_TEMPLATE.md
@@ -1,0 +1,13 @@
+# Specification Template
+
+## Overview
+Summarize the component or feature described.
+
+## Requirements
+List functional and non-functional requirements.
+
+## Diagrams
+Include sequence, state, or other diagrams as needed.
+
+## References
+Link to related documents or tickets.

--- a/docs/spc/examples/sequence_example.puml
+++ b/docs/spc/examples/sequence_example.puml
@@ -1,0 +1,4 @@
+@startuml
+Alice -> Bob: Hello
+Bob --> Alice: Hi
+@enduml

--- a/docs/spc/spec_prompts.md
+++ b/docs/spc/spec_prompts.md
@@ -1,0 +1,8 @@
+# Specification Prompts
+
+Use these prompts to ensure specifications are complete:
+
+1. "Describe the motivation and context for this specification."
+2. "Enumerate all requirements with clear identifiers."
+3. "Provide diagrams that illustrate system behavior." 
+4. "Reference related documents or tickets for traceability."

--- a/linters/diagram_linter.py
+++ b/linters/diagram_linter.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Simple PlantUML diagram linter."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from lint_utils import check_no_todo
+
+
+def check_puml(path: Path) -> bool:
+    lines = path.read_text().splitlines()
+    if not lines:
+        print(f"{path}: file is empty")
+        return False
+    if not lines[0].startswith('@start'):
+        print(f"{path}: missing @startuml")
+        return False
+    if not lines[-1].startswith('@end'):
+        print(f"{path}: missing @enduml")
+        return False
+    return True
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Diagram linter")
+    parser.add_argument("files", nargs="+", help="Diagram files to lint")
+    args = parser.parse_args(argv)
+
+    for path_str in args.files:
+        path = Path(path_str)
+        if not path.exists():
+            print(f"File not found: {path}")
+            return 1
+        if not check_no_todo(path):
+            return 1
+        if path.suffix == '.puml' and not check_puml(path):
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/task_17/README.md
+++ b/tasks/task_17/README.md
@@ -1,0 +1,18 @@
+# Dialogs for task 17
+
+## Review for Task 17
+**Responsible:** Systems Analyst
+**Reviewer:** Architect
+
+### Task Description
+Populate specification folder (`docs/spc/`) with templates, prompts, examples and diagram linters.
+
+### Review Notes
+- **Clarity:** Requires simple templates and a diagram linter.
+- **Blockers:** None identified.
+- **Resources:** `docs/planning/PROJECT_PLAN.md`, `docs/ROLES_PROMPTS.md`
+
+## AI Notes 2025-05-31
+- Followed Systems Analyst and Architect prompts.
+- Created specification templates and example diagram under `docs/spc/`.
+- Implemented `diagram_linter.py` and tests.

--- a/tasks/task_17/followups.md
+++ b/tasks/task_17/followups.md
@@ -1,0 +1,3 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 16
+- Reference: ../../docs/spc/README.md

--- a/tests/test_linter_cli.py
+++ b/tests/test_linter_cli.py
@@ -9,6 +9,7 @@ LINTERS = [
     'linters/testplan_linter.py',
     'linters/code_linter.py',
     'linters/role_linter.py',
+    'linters/diagram_linter.py',
 ]
 
 def run_linter(script, file):
@@ -19,8 +20,15 @@ def test_linter_pass(tmp_path):
     target.write_text("All good\n")
     role = tmp_path / "role.md"
     role.write_text("# Dev\nPrompt\n")
+    diagram = tmp_path / "diagram.puml"
+    diagram.write_text("@startuml\nA->B: hi\n@enduml\n")
     for script in LINTERS:
-        file = role if script.endswith("role_linter.py") else target
+        if script.endswith("role_linter.py"):
+            file = role
+        elif script.endswith("diagram_linter.py"):
+            file = diagram
+        else:
+            file = target
         result = run_linter(script, str(file))
         assert result.returncode == 0, result.stderr
 
@@ -29,8 +37,15 @@ def test_linter_fail(tmp_path):
     target.write_text("TODO: fix me\n")
     role = tmp_path / "role_bad.md"
     role.write_text("# Dev\nTODO: bad\n")
+    diagram = tmp_path / "diagram_bad.puml"
+    diagram.write_text("@startuml\nTODO: bad\n@enduml\n")
     for script in LINTERS:
-        file = role if script.endswith("role_linter.py") else target
+        if script.endswith("role_linter.py"):
+            file = role
+        elif script.endswith("diagram_linter.py"):
+            file = diagram
+        else:
+            file = target
         result = run_linter(script, str(file))
         assert result.returncode == 1
         assert b"contains TODO" in result.stdout


### PR DESCRIPTION
## Summary
- add `docs/spc` with specification templates and example diagram
- implement `diagram_linter.py` to validate PlantUML files
- extend unit tests for the new linter
- complete task 17 in the project plan
- record task dialog and lessons learned

## Testing
- `pytest -q`
- `python linters/doc_linter.py docs/spc/README.md`
- `python linters/diagram_linter.py docs/spc/examples/sequence_example.puml`


------
https://chatgpt.com/codex/tasks/task_e_683ac28981b8832c95f9d1c21ece3145