### PR TITLE
Add audit tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,4 @@ After completing a task:
 - Verify role documents with `doc_linter` after updating methodologies.
 - Place architecture templates in a dedicated folder and provide a specific linter.
 - Create combined role prompt files when tasks reference multiple roles to avoid script errors.
+- Clarify artifact ownership by including a `Responsible Role` section in templates.

--- a/docs/planning/PROJECT_PLAN.md
+++ b/docs/planning/PROJECT_PLAN.md
@@ -33,6 +33,9 @@
 | 25 | **Define QA Lead methodologies** (`docs/roles/qa_lead.md`) | QA Lead | Support Lead | Document describes test automation and BDD; passes `doc_linter`. | Pending |
 | 26 | **Define Support Lead methodologies** (`docs/roles/support_lead.md`) | Support Lead | Project Manager | Document includes ITIL processes and root cause analysis; passes `doc_linter`. | Pending |
 | 27 | **Refactor role prompts** (`src/role_utils.py`, template + linter) | Programmer | QA Lead | Role registry lists slugs only; prompts stored separately; linter validates each role file. | Pending |
+| 28 | **Integrate metrics scripts into workflow** (`metrics.yml`) | DevOps | Architect | `metrics.yml` runs scripts from task 6 and pushes results; CI shows success. | Pending |
+| 29 | **Audit role methodology documents** (`docs/roles/*.md`) | QA Lead | Project Manager | Each role file lists at least three methodologies and passes `doc_linter`; tasks 20‑26 marked Done. | Pending |
+| 30 | **Add Responsible Role field to templates** (`docs/*_TEMPLATE.md`, examples, `linters/artifact_role_linter.py`) | Architect | Systems Analyst, Programmer | Templates and examples include a `Responsible Role` section; new linter ensures presence. | Pending |
 > **Progress Tracking:** Update the Status column and add ✅ in the DoD column once criteria are met.
 
 ---

--- a/tasks/task_07/followups.md
+++ b/tasks/task_07/followups.md
@@ -1,3 +1,3 @@
 - Reference: ../../docs/planning/PROJECT_PLAN.md
 - Depends on: 5, 6
-- Follow up: integrate metrics scripts into metrics workflow after task 6
+- Follow up: integrate metrics scripts into metrics workflow after task 6 (see Task 28)

--- a/tasks/task_28/README.md
+++ b/tasks/task_28/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 28

--- a/tasks/task_28/followups.md
+++ b/tasks/task_28/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 6, 7

--- a/tasks/task_29/README.md
+++ b/tasks/task_29/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 29

--- a/tasks/task_29/followups.md
+++ b/tasks/task_29/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 20, 21, 22, 23, 24, 25, 26

--- a/tasks/task_30/README.md
+++ b/tasks/task_30/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 30

--- a/tasks/task_30/followups.md
+++ b/tasks/task_30/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 3, 16, 17


### PR DESCRIPTION
## Summary
- add tasks 29 and 30 for role doc review and artifact ownership
- add followup files for the new tasks
- note artifact ownership in Lessons Learned

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b069f92f4832cb0073356645a7510