### PR TITLE
Update architect methodologies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,4 @@ After completing a task:
 - Create combined role prompt files when tasks reference multiple roles to avoid script errors.
 - Clarify artifact ownership by including a `Responsible Role` section in templates.
 - Confirm prerequisite tasks are completed before marking dependent tasks Done.
+- Leave a task pending if prerequisites are incomplete, even when the artifact is finished.

--- a/docs/roles/architect.md
+++ b/docs/roles/architect.md
@@ -1,2 +1,8 @@
 # Architect
 Design the technical structure. Review tasks for architectural consistency and scalability.
+
+## Methodologies
+
+- **Domain-Driven Design**: Define bounded contexts and align code with domain concepts. Work closely with subject matter experts to model the core domain.
+- **Architecture Patterns**: Apply patterns such as layered, microservices and event-driven designs to create scalable, maintainable systems.
+- **Documentation & Review**: Keep diagrams and documents current and verify each task aligns with the selected patterns and performance goals.

--- a/tasks/task_21/README.md
+++ b/tasks/task_21/README.md
@@ -1,1 +1,6 @@
 # Dialogs for task 21
+
+- Selected via `python src/random_task.py`.
+- Added Domain-Driven Design and architecture pattern guidelines to `docs/roles/architect.md`.
+- Confirmed the document passes `doc_linter`.
+- Did not mark the task complete because task 19 remains pending.

--- a/tasks/task_21/followups.md
+++ b/tasks/task_21/followups.md
@@ -1,2 +1,3 @@
 - Reference: ../../docs/planning/PROJECT_PLAN.md
 - Depends on: 19
+- Action: Update project plan status once task 19 is finished.


### PR DESCRIPTION
## Summary
- expand `docs/roles/architect.md` with Domain-Driven Design and pattern guidance
- record decisions for task 21
- note dependency on task 19 in followups
- document lesson learned about keeping tasks pending until prerequisites are done

## Testing
- `pytest -q`
- `python linters/doc_linter.py docs/roles/architect.md`


------
https://chatgpt.com/codex/tasks/task_e_683c117165cc832cbfd0ea1cae0e2fa5