### PR TITLE
Plan local LLM glossary tasks

### DIFF
--- a/docs/planning/PROJECT_PLAN.md
+++ b/docs/planning/PROJECT_PLAN.md
@@ -36,6 +36,12 @@
 | 28 | **Integrate metrics scripts into workflow** (`metrics.yml`) | DevOps | Architect | `metrics.yml` runs scripts from task 6 and pushes results; CI shows success. | Pending |
 | 29 | **Audit role methodology documents** (`docs/roles/*.md`) | QA Lead | Project Manager | Each role file lists at least three methodologies and passes `doc_linter`; tasks 20‑26 marked Done. | Pending |
 | 30 | **Add Responsible Role field to templates** (`docs/*_TEMPLATE.md`, examples, `linters/artifact_role_linter.py`) | Architect | Systems Analyst, Programmer | Templates and examples include a `Responsible Role` section; new linter ensures presence. | Pending |
+| 31 | **Create tasks for glossary development department** (plan LLM-driven glossary system) | Project Manager | Architect | New tasks enumerated for local LLM glossary department with dependencies mapped; doc_linter passes. | Pending |
+| 32 | **Document glossary system requirements** (`docs/glossary_system/REQUIREMENTS.md`) | Systems Analyst | Architect | Requirements file describes features and constraints for local LLM glossary department; passes `doc_linter`. | Pending |
+| 33 | **Design glossary department architecture** (`docs/glossary_system/ARCHITECTURE.md`) | Architect | Programmer | Architecture document outlines agents and data flow for glossary generation; passes `architecture_linter`. | Pending |
+| 34 | **Prepare data and training pipeline** (`src/glossary_pipeline/`) | Programmer | QA Lead | Data pipeline scripts and tests added; passes `code_linter` and `pytest`. | Pending |
+| 35 | **Implement local LLM glossary agents** (`src/glossary_agents/`) | Programmer | QA Lead | Agents generate glossary terms using local model; code passes `code_linter`. | Pending |
+| 36 | **Evaluate glossary generation system** (`docs/glossary_system/EVALUATION.md`) | QA Lead | Support Lead | Evaluation report details accuracy and improvements; passes `doc_linter`. | Pending |
 > **Progress Tracking:** Update the Status column and add ✅ in the DoD column once criteria are met.
 
 ---

--- a/tasks/task_31/README.md
+++ b/tasks/task_31/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 31

--- a/tasks/task_31/followups.md
+++ b/tasks/task_31/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: none

--- a/tasks/task_32/README.md
+++ b/tasks/task_32/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 32

--- a/tasks/task_32/followups.md
+++ b/tasks/task_32/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 31

--- a/tasks/task_33/README.md
+++ b/tasks/task_33/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 33

--- a/tasks/task_33/followups.md
+++ b/tasks/task_33/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 32

--- a/tasks/task_34/README.md
+++ b/tasks/task_34/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 34

--- a/tasks/task_34/followups.md
+++ b/tasks/task_34/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 33

--- a/tasks/task_35/README.md
+++ b/tasks/task_35/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 35

--- a/tasks/task_35/followups.md
+++ b/tasks/task_35/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 34

--- a/tasks/task_36/README.md
+++ b/tasks/task_36/README.md
@@ -1,0 +1,1 @@
+# Dialogs for task 36

--- a/tasks/task_36/followups.md
+++ b/tasks/task_36/followups.md
@@ -1,0 +1,2 @@
+- Reference: ../../docs/planning/PROJECT_PLAN.md
+- Depends on: 35


### PR DESCRIPTION
## Summary
- expand project plan with tasks 32-36 for a local LLM glossary department
- add folders for tasks 32-36 with references and dependencies

## Testing
- `python linters/doc_linter.py $(git ls-files '*.md')`
- `python linters/srs_linter.py $(git ls-files '*.md')`
- `python linters/testplan_linter.py $(git ls-files '*.md')`
- `files=$(git ls-files '*.py' | grep -v 'tests/test_linter_cli.py'); python linters/code_linter.py $files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683c93a7d654832ca5443347a0e91699